### PR TITLE
Added tailwind typography plugin

### DIFF
--- a/src/components/PathViewer.tsx
+++ b/src/components/PathViewer.tsx
@@ -15,7 +15,6 @@ const PathViewer = (props: PathViewerProps) => {
     useEffect(() => {
         client.queries.path({ relativePath: `${props.slug}.mdx` }).then((path) => {
             setPath(path.data.path);
-            console.log(path);
         });
     }, []);
 
@@ -35,7 +34,7 @@ const PathViewer = (props: PathViewerProps) => {
                         {current >= 0 ? (
                             <>
                                 <h2 className="text-3xl">{path.path[current].place.title}</h2>
-                                <TinaMarkdown content={path.path[current].blurb} />
+                                <article className="prose"><TinaMarkdown content={path.path[current].blurb} /></article>
                                 <div className="flex flex-row pt-16 w-full justify-between py-16">
                                     <div onClick={() => current > 0 && setCurrent((i) => i - 1)} className={current == 0 ? 'text-gray-500 cursor-default' : 'cursor-pointer'}>Previous</div>
                                     <div onClick={() => current < path.path.length - 1 && setCurrent((i) => i + 1)} className={current == path.path.length - 1 ? 'text-gray-500 cursor-default' : 'cursor-pointer'}>Next</div>
@@ -44,7 +43,7 @@ const PathViewer = (props: PathViewerProps) => {
                         ) : (
                             <>
                                 <h2 className="text-3xl">{path.title}</h2>
-                                <TinaMarkdown content={path.description} />
+                                <article className="prose prose-xl"><TinaMarkdown content={path.description} /></article>
                                 <div className="cursor-pointer" onClick={() => setCurrent(0)}>Begin Path</div>
                             </>
                         )}

--- a/src/components/PostContent.tsx
+++ b/src/components/PostContent.tsx
@@ -21,7 +21,9 @@ const PostContent = (props: PostContentProps) => {
     return (
         <div>
             <h1 className="text-3xl py-6">{title}</h1>
-            <TinaMarkdown content={content} components={{ place: PlaceInsert }} />
+            <article className="prose">
+                <TinaMarkdown content={content} components={{ place: PlaceInsert }} />
+            </article>
         </div>
     )
 };

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -4,5 +4,7 @@ export default {
 	theme: {
 		extend: {},
 	},
-	plugins: [],
+	plugins: [
+		require('@tailwindcss/typography'),
+	],
 }


### PR DESCRIPTION
### In this PR
Added the Typography plugin for Tailwind, which allows for more fine-grained styling of markdown components coming from Tina. In particular, right out of the box this addresses Issue #9 about giving links within posts/paths a visual treatment that identifies them as links.
![image](https://github.com/performant-software/gbof-astro/assets/110847635/2c48a651-e490-47a4-8758-ea4e2aae3252)

### Notes
With this plugin, further custom styles can be added as needed to further customize the rendering of the rich text components.