### PR TITLE
Changed path detail view to have vertical scroll

### DIFF
--- a/src/components/PathViewer.tsx
+++ b/src/components/PathViewer.tsx
@@ -28,7 +28,7 @@ const PathViewer = (props: PathViewerProps) => {
                     defaultZoom={16}
                 /> : path && <img src={path.image} className="w-full" />}
             </div>
-            <div className="h-full w-1/2">
+            <div className="h-full w-1/2 overflow-y-scroll">
                 {path && (
                     <div className="flex flex-col py-16 px-12 gap-16">
                         {current >= 0 ? (


### PR DESCRIPTION
### In this PR
Pursuant to Issue #11 , this PR modifies the behavior of the right-hand panel in the path viewer to scroll independently of the map when the content is longer than the viewport.
![image](https://github.com/performant-software/gbof-astro/assets/110847635/5a05e8a1-45e7-4f87-9bef-5efc163fdeb6)
![image](https://github.com/performant-software/gbof-astro/assets/110847635/11d4d9fa-c40a-411f-bfcc-24df004a04a2)
