### PR TITLE
Improved path navigation

### DIFF
--- a/src/components/PathViewer.tsx
+++ b/src/components/PathViewer.tsx
@@ -33,6 +33,7 @@ const PathViewer = (props: PathViewerProps) => {
                     <div className="flex flex-col py-16 px-12 gap-16">
                         {current >= 0 ? (
                             <>
+                                <div onClick={() => setCurrent(-1)} className="cursor-pointer">Go Back</div>
                                 <h2 className="text-3xl">{path.path[current].place.title}</h2>
                                 <article className="prose"><TinaMarkdown content={path.path[current].blurb} /></article>
                                 <div className="flex flex-row pt-16 w-full justify-between py-16">

--- a/src/components/PathViewer.tsx
+++ b/src/components/PathViewer.tsx
@@ -33,7 +33,7 @@ const PathViewer = (props: PathViewerProps) => {
                     <div className="flex flex-col py-16 px-12 gap-16">
                         {current >= 0 ? (
                             <>
-                                <div onClick={() => setCurrent(-1)} className="cursor-pointer">Go Back</div>
+                                <div onClick={() => setCurrent(-1)} className="cursor-pointer">Back to Beginning</div>
                                 <h2 className="text-3xl">{path.path[current].place.title}</h2>
                                 <article className="prose"><TinaMarkdown content={path.path[current].blurb} /></article>
                                 <div className="flex flex-row pt-16 w-full justify-between py-16">


### PR DESCRIPTION
### In this PR
Adds a(n as of now unstyled) "Back to Beginning" navigation to the interface of a given stop along a path, which will reset the viewer to the "cover" page of the path. Addresses Issue #15 
![image](https://github.com/performant-software/gbof-astro/assets/110847635/6cec2317-f41a-4644-9f7d-fe5596803f21)
